### PR TITLE
add climate indices from psl noaa

### DIFF
--- a/catalogs/climate.yaml
+++ b/catalogs/climate.yaml
@@ -52,10 +52,10 @@ sources:
       index:
         description: name of the index
         type: str
-        default: Nina_34
-        allowed: [CAR, EA, HAW, IND, Nina4, Nina_34, NTA, STA]
+        default: Nina34
+        allowed: [CAR, EA, HAW, IND, Nina4, Nina34, NTA, STA]
     args:
-      urlpath: simplecache::ftp://ftp.cdc.noaa.gov/Datasets/Timeseries/{{index}}_ersst.data
+      urlpath: ftp://ftp.cdc.noaa.gov/Datasets/Timeseries/{{index}}_ersst.data
       csv_kwargs:
         sep: '   '
         skiprows: 2

--- a/catalogs/climate.yaml
+++ b/catalogs/climate.yaml
@@ -20,3 +20,24 @@ sources:
         sheet_name: 'Global Carbon Budget'
         index_col: Year
         skipfooter: 4
+
+  indices:
+    description: climate indices from psl.noaa.gov/data/correlation
+    metadata:
+      url: https://www.psl.noaa.gov/data/correlation/
+    driver: csv
+    parameters:
+      index:
+        description: name of the index
+        default: nina34
+        allowed: [pna, wp, ea, nao, jonesnao, soi, nina3, censo, oni, nina1, nina4, nina34, np, hurr, pacwarm, swmonsoon]
+    args:
+      urlpath: https://psl.noaa.gov/data/correlation/{{index}}.data
+      csv_kwargs:
+        sep: '  '
+        skiprows: 3
+        skipfooter: 3
+        names: ['year', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+        #index_col: 'year' not allowed by dd.read_csv but pd.read_csv
+        na_values: [-999.90,'-999.90','-99.90',-99.90]
+        engine: python

--- a/catalogs/climate.yaml
+++ b/catalogs/climate.yaml
@@ -55,7 +55,7 @@ sources:
         default: Nina34
         allowed: [CAR, EA, HAW, IND, Nina4, Nina34, NTA, STA]
     args:
-      urlpath: ftp://ftp.cdc.noaa.gov/Datasets/Timeseries/{{index}}_ersst.data
+      urlpath: simplecache::ftp://ftp.cdc.noaa.gov/Datasets/Timeseries/{{index}}_ersst.data
       csv_kwargs:
         sep: '   '
         skiprows: 2

--- a/catalogs/climate.yaml
+++ b/catalogs/climate.yaml
@@ -21,7 +21,7 @@ sources:
         index_col: Year
         skipfooter: 4
 
-  indices:
+  NOAA_correlation:
     description: climate indices from psl.noaa.gov/data/correlation
     metadata:
       url: https://www.psl.noaa.gov/data/correlation/
@@ -30,9 +30,10 @@ sources:
       index:
         description: name of the index
         default: nina34
+        type: str
         allowed: [pna, wp, ea, nao, jonesnao, soi, nina3, censo, oni, nina1, nina4, nina34, np, hurr, pacwarm, swmonsoon]
     args:
-      urlpath: https://psl.noaa.gov/data/correlation/{{index}}.data
+      urlpath: simplecache::https://psl.noaa.gov/data/correlation/{{index}}.data
       csv_kwargs:
         sep: '  '
         skiprows: 3
@@ -40,4 +41,25 @@ sources:
         names: ['year', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
         #index_col: 'year' not allowed by dd.read_csv but pd.read_csv
         na_values: [-999.90,'-999.90','-99.90',-99.90]
+        engine: python
+
+  NOAA_SST_anomaly_timeseries:
+    description: Sea Surface Temperature Anomaly Indices derived from ERSST
+    metadata:
+      url: https://www.psl.noaa.gov/forecasts/sstlim/timeseries/
+    driver: csv
+    parameters:
+      index:
+        description: name of the index
+        type: str
+        default: Nina_34
+        allowed: [CAR, EA, HAW, IND, Nina4, Nina_34, NTA, STA]
+    args:
+      urlpath: simplecache::ftp://ftp.cdc.noaa.gov/Datasets/Timeseries/{{index}}_ersst.data
+      csv_kwargs:
+        sep: '   '
+        skiprows: 2
+        skipfooter: 8
+        names: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+        #index_col: 'year' not allowed by dd.read_csv but pd.read_csv
         engine: python

--- a/catalogs/ocean.yaml
+++ b/catalogs/ocean.yaml
@@ -147,7 +147,7 @@ sources:
         default: '01'
         allowed: ['5d', '01', '04']
     args:
-      urlpath: simplecache::https://data.nodc.noaa.gov/thredds/dodsC/ncei/woa/{{variable}}/{{DDDD}}/{{GG}}/woa18_{{DDDD}}_{{variable[0]}}{{ "%02d" | format(TT) }}_{{GG2}}.nc
+      urlpath: https://data.nodc.noaa.gov/thredds/dodsC/ncei/woa/{{variable}}/{{DDDD}}/{{GG}}/woa18_{{DDDD}}_{{variable[0]}}{{ "%02d" | format(TT) }}_{{GG2}}.nc
       xarray_kwargs:
         decode_times: false
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.6
   - intake
   - xarray
+  - pydap
   - dask
   - fsspec
   - requests
@@ -26,5 +27,5 @@ dependencies:
       - git+https://github.com/edjdavid/intake-excel.git
       - xlrd==1.2.0  # newer versions dont support xlsx
       - git+https://github.com/intake/intake-xarray.git
-      - git+https://github.com/geopandas/geopandas.git 
+      - git+https://github.com/geopandas/geopandas.git
       - git+https://github.com/intake/intake_geopandas.git # ordering is critical here, has to be last

--- a/tests/test_remote_catalog.py
+++ b/tests/test_remote_catalog.py
@@ -13,16 +13,18 @@ def test_check_all_items():
     """Test all items.to_dask() except ceda requiring credentials"""
     for item_str in cat.walk(depth=3):
         print(item_str)
-        if 'CRU_TS' not in item_str: # avoids also CRU datasets requiring credentials at ceda
+        if 'CRU_TS' in item_str:
+            print('avoid testing CRU_TS requiring credentials at ceda')
+        else:
             item = getattr(cat, item_str)
-            if isinstance(item, intake_xarray.netcdf.NetCDFSource) and item_str not in ['ocean.SOM_FFN', 'ocean.CSIR-ML6']:  # avoids too large (>500MB) datasets
+            if isinstance(item, (intake_xarray.NetCDFSource,intake_xarray.OpenDapSource)) and item_str not in ['ocean.SOM_FFN', 'ocean.CSIR-ML6']:  # avoids too large (>500MB) datasets
                 ds = item.to_dask()
                 assert isinstance(ds, xr.Dataset), print(item_str, 'could be accessed by to_dask() but isnt xr.Dataset')
                 print('successfully tested', item_str, '\n',type(item), '\n', ds.dims, '\n', ds.coords, '\nsize = ', format_bytes(ds.nbytes), '\n')
             elif isinstance(item, (intake_geopandas.RegionmaskSource, intake_geopandas.ShapefileSource)):
                 region = item.read()
                 print('successfully tested', item_str, '\n', type(item))
-            elif isinstance(item, intake_excel.ExcelSource):
+            elif isinstance(item, (intake.source.csv.CSVSource,intake_excel.ExcelSource)):
                 df = item.read()
                 print('successfully tested', item_str, '\n', type(df),'\n', df.head())
             else:

--- a/tests/test_remote_catalog.py
+++ b/tests/test_remote_catalog.py
@@ -14,7 +14,7 @@ def test_check_all_items():
     for item_str in cat.walk(depth=3):
         print(item_str)
         if 'CRU_TS' in item_str:
-            print('avoid testing CRU_TS requiring credentials at ceda')
+            print('avoid testing CRU_TS requiring credentials at ceda\n')
         else:
             item = getattr(cat, item_str)
             if isinstance(item, (intake_xarray.NetCDFSource,intake_xarray.OpenDapSource)) and item_str not in ['ocean.SOM_FFN', 'ocean.CSIR-ML6']:  # avoids too large (>500MB) datasets

--- a/utils/convert.py
+++ b/utils/convert.py
@@ -1,0 +1,11 @@
+import pandas as pd
+import xarray as xr
+    
+def monthly_csv_to_DataArray(df):
+    df=df.set_index('year')
+    df = df.apply(pd.to_numeric,errors='coerce')
+    initial = df.first_valid_index()
+    if len(str(initial))>=4:
+        initial = str(initial)[:4]
+    initial = int(initial)
+    return xr.DataArray(df.values.flatten(),dims='time',coords={'time':xr.cftime_range(str(initial),freq='MS',periods=df.values.size)})


### PR DESCRIPTION
Adds:
 - [x] climate indices in csv format from psl.noaa.gov
 - [x] helper function to convert these to xr.DataArrays

Can be extended:
- [ ] creating subcatalog with more indices from psl.noaa
- [ ] many correlations kicked out for data formatting reasons
- [ ] timeseries: https://www.psl.noaa.gov/data/timeseries/monthly/

```python
import pandas as pd
indices = ['pna','wp','ea','nao','jonesnao','soi','nina3','censo','oni','nina1','nina4','nina34','np','hurr','pacwarm','swmonsoon']
fig,ax=plt.subplots(nrows=len(indices),figsize=(8,20),sharex=True)
for i,index in enumerate(indices):
    url = f'https://psl.noaa.gov/data/correlation/{index}.data'
    print(index, url) 
    df = cat.climate.indices(index=index).read()
    da = monthly_csv_to_DataArray(df)
    da.plot(ax=ax[i])
    ax[i].set_title(f'{index.upper()} from {url}')
plt.tight_layout()
```

![image](https://user-images.githubusercontent.com/12237157/102068823-3b8c4200-3dfd-11eb-8aea-4216802efc12.png)
